### PR TITLE
Create composer.json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@ A PHP 5.3+ payment gateway class for spanish banks that use Sermepa/Redsys syste
 
 Full list of banks managed by [sermepa](http://www.redsys.es/wps/portal/redsys/publica/acercade/nuestrosSocios)
 
+## Usage with Composer
+
+To include it in your application using Composer, you can just include in your `composer.json` file:
+
+```json
+"repositories": [
+  {
+    "type": "git",
+    "url": "URL_OF_THIS_REPOSITORY"
+  }
+],
+
+"require": {
+  "commerce_redsys/sermepa": "dev-master"
+},
+```
+
 ----------
 
 License

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+  "name": "commerce_redsys/sermepa",
+  "description": "SERMEPA library for PHP projects.",
+  "keywords":     ["sermepa", "payment"],
+  "homepage":     "https://github.com/CommerceRedsys/sermepa",
+  "type":         "library",
+  "license":      "MIT",
+  "autoload": {
+    "psr-4": {
+        "CommerceRedsys\\Payment\\": "src/"
+    }
+  },
+  "require": {
+    "php": ">=5.3"
+  },
+  "minimum-stability": "dev"
+}


### PR DESCRIPTION
In order to use it in libraries for modern PHP frameworks (like Drupal 8) it's mandatory to include a `composer.json` file, so the dependency can be required, installed and autoloaded.

If a file like this isn't included in the repo, the solution will be copying the files within other libraries' repositories (as composer doesn't offer support for git submodules).