### PR TITLE
Fix password generation on PHP 7.1+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "commerce_redsys/sermepa",
+  "name": "commerceredsys/sermepa",
   "description": "SERMEPA library for PHP projects.",
   "keywords":     ["sermepa", "payment"],
   "homepage":     "https://github.com/CommerceRedsys/sermepa",

--- a/src/Sermepa.php
+++ b/src/Sermepa.php
@@ -347,9 +347,19 @@ class Sermepa implements SermepaInterface {
     // PHP 4 >= 4.0.2.
     $iv = implode(array_map("chr", $bytes));
 
-    // Return encrypted order number with decoded SHA256 password.
-    // PHP 4 >= 4.0.2.
-    return mcrypt_encrypt(MCRYPT_3DES, $merchant_password, $order_number, MCRYPT_MODE_CBC, $iv);
+    if ((PHP_MAJOR_VERSION > 7) || (PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION >= 1)) {
+      // Manually add padding
+      $block = 8; // DES3 block size
+      $pad = $block - (strlen($order_number) % $block);
+      $padded_order_number = $order_number . str_repeat(chr(0), $pad);
+
+      // Encrypt using OpenSSL
+      return openssl_encrypt($padded_order_number, 'DES3', $merchant_password, OPENSSL_NO_PADDING);
+    } else {
+      // Return encrypted order number with decoded SHA256 password.
+      // PHP 4 >= 4.0.2.
+      return mcrypt_encrypt(MCRYPT_3DES, $merchant_password, $order_number, MCRYPT_MODE_CBC, $iv);
+    }
   }
 
   /**

--- a/src/Sermepa.php
+++ b/src/Sermepa.php
@@ -354,7 +354,8 @@ class Sermepa implements SermepaInterface {
       $padded_order_number = $order_number . str_repeat(chr(0), $pad);
 
       // Encrypt using OpenSSL
-      return openssl_encrypt($padded_order_number, 'DES3', $merchant_password, OPENSSL_NO_PADDING);
+      // Errors are ommited because Sermepa uses an empty IV, which causes a warning because it's insecure.
+      return @openssl_encrypt($padded_order_number, 'DES3', $merchant_password, OPENSSL_NO_PADDING);
     } else {
       // Return encrypted order number with decoded SHA256 password.
       // PHP 4 >= 4.0.2.

--- a/src/Sermepa.php
+++ b/src/Sermepa.php
@@ -349,23 +349,15 @@ class Sermepa implements SermepaInterface {
     // Set default IV value.
     // byte [] IV = {0, 0, 0, 0, 0, 0, 0, 0}.
     $bytes = array(0, 0, 0, 0, 0, 0, 0, 0);
-    // PHP 4 >= 4.0.2.
-    $iv = implode(array_map("chr", $bytes));
+    $iv = implode(array_map('chr', $bytes));
 
-    if ((PHP_MAJOR_VERSION > 7) || (PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION >= 1)) {
-      // Manually add padding
-      $block = 8; // DES3 block size
-      $pad = $block - (strlen($order_number) % $block);
-      $padded_order_number = $order_number . str_repeat(chr(0), $pad);
+    // Manually add padding
+    $block = 8; // DES3 block size
+    $pad = $block - (strlen($order_number) % $block);
+    $padded_order_number = $order_number . str_repeat(chr(0), $pad);
 
-      // Encrypt using OpenSSL
-      // Errors are ommited because Sermepa uses an empty IV, which causes a warning because it's insecure.
-      return @openssl_encrypt($padded_order_number, 'DES3', $merchant_password, OPENSSL_NO_PADDING);
-    } else {
-      // Return encrypted order number with decoded SHA256 password.
-      // PHP 4 >= 4.0.2.
-      return mcrypt_encrypt(MCRYPT_3DES, $merchant_password, $order_number, MCRYPT_MODE_CBC, $iv);
-    }
+    // Return encrypted order number using OpenSSL with decoded SHA256 password.
+    return openssl_encrypt($padded_order_number, 'DES3', $merchant_password, OPENSSL_RAW_DATA | OPENSSL_NO_PADDING, $iv);
   }
 
   /**

--- a/src/Sermepa.php
+++ b/src/Sermepa.php
@@ -351,8 +351,9 @@ class Sermepa implements SermepaInterface {
     $bytes = array(0, 0, 0, 0, 0, 0, 0, 0);
     $iv = implode(array_map('chr', $bytes));
 
-    // Manually add padding
-    $block = 8; // DES3 block size
+    // Manually add padding.
+    // DES3 block size.
+    $block = 8;
     $pad = $block - (strlen($order_number) % $block);
     $padded_order_number = $order_number . str_repeat(chr(0), $pad);
 


### PR DESCRIPTION
In PHP 7.1, `mcrypt` extension has been deprecated and it's planned to be removed in 7.1+1.

The patch in this PR uses OpenSSL encryption in PHP 7.1+ , so the deprecation message gone away.
However, an `insecure IV is used` warning appears, as Sermepa use an empty IV (but this is difficult to solve :smile: ).

I've maintained the `mcrypt` method for older versions, as it doesn't produce any warning.

EDIT: More info about deprecation: https://why-cant-we-have-nice-things.mwl.be/requests/deprecate-then-remove-mcrypt